### PR TITLE
health(input): Sanitize input data

### DIFF
--- a/benchmarks/000.microbenchmarks/010.sleep/python/function.py
+++ b/benchmarks/000.microbenchmarks/010.sleep/python/function.py
@@ -2,8 +2,12 @@
 from time import sleep
 
 def handler(event):
-
     # start timing
-    sleep_time = event.get('sleep')
+    sleep_time = event.get("sleep", default=False)
+    if not sleep_time:
+        return 'Error: No key "sleep" found on input data.'
+    elif not isinstance(sleep_time, (int, float)):
+        return f'Error: Key "sleep" expected int or float, not {type(sleep_time)}.'
+
     sleep(sleep_time)
     return { 'result': sleep_time }

--- a/dockerfiles/local/python/server.py
+++ b/dockerfiles/local/python/server.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import sys
 import uuid
+from json.decoder import JSONDecodeError
 
 import bottle
 from bottle import route, run, template, request
@@ -14,7 +15,20 @@ def flush_log():
     from function import function
     end = datetime.datetime.now()
     # FIXME: measurements?
-    ret = function.handler(request.json)
+
+    try:
+        # The following assignment could raise a JSONDecodeError
+        data = request.json
+
+        # Error if empty JSON content or Content-Type is not application/json
+        if not data:
+            ret = 'Error: Empty JSON content or invalid Content-Type in request.'
+
+        # If no parsing error is found, the data can be recieved by the handler
+        else:
+            ret = function.handler(data)
+    except JSONDecodeError as err:
+        ret = 'Error: Unable to decode JSON content in request.'
 
     return {
         'begin': begin.strftime('%s.%f'),


### PR DESCRIPTION
## Feature

The following feature adds input sanitization for the main `server.py` API, handling both empty JSON requests and incorrect errors that would otherwise raise `JSONDecodeErrors` on the server.

It also starts to work on data input sanitization for benchmarks, including an example for the `handler()` function available in `010.sleep`.

## Changes

- [x] Handle `JSONDecodeError` on `--data` flag.
- [x] Handle empty JSON on `--data` flag.
- [x] Handle missing key on input data for `010.sleep`.
- [x] Handle incorrect type on input data for `010.sleep`.

## Future work

- [ ]  Expand missing key handling on all benchmarks.
- [ ] Expand incorrect type handling on all benchmarks.